### PR TITLE
add csproj and exception for it in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Rider settings directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 
@@ -70,3 +73,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Don't ignore main csproj file
+!DragonECS.csproj

--- a/DragonECS.csproj
+++ b/DragonECS.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <LangVersion>8</LangVersion>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <None Remove="**/*.meta" />
+      <None Remove="package.json" />
+      <None Remove="DragonECS.asmdef" />
+    </ItemGroup>
+    
+</Project>


### PR DESCRIPTION
Add:
> ./DragonEcs.csproj - so project can be used in dotnet without need to integrate in existing code base or create own

Change:
> add exception for exact DragonEcs.csproj
> ignore ./idea - Intellij settings dir