### PR TITLE
Add nullifying item in WorldComponentPool<T> Release method

### DIFF
--- a/src/EcsWorld.static.cs
+++ b/src/EcsWorld.static.cs
@@ -241,6 +241,7 @@ namespace DCFApixels.DragonECS
                         {
                             Array.Resize(ref _recycledItems, _recycledItems.Length << 1);
                         }
+                        _items[itemIndex] = default;
                         _recycledItems[_recycledItemsCount++] = itemIndex;
                         itemIndex = 0;
                     }


### PR DESCRIPTION
Столкнулся, что в Unity без Domain Reload компоненты на мире не очищаются. Данное решение решило проблему. Возможно, стоит добавить зануление и в обычный EcsPool.